### PR TITLE
Célula de carga

### DIFF
--- a/Célula de Carga/Readme
+++ b/Célula de Carga/Readme
@@ -1,0 +1,1 @@
+#Célula de carga


### PR DESCRIPTION
                                         **STRAIN GAUGES**

**Introdução**

                       O nome extensômetro significa medidor de deformação. O nome extensômetro de resistência elétrica significa medidor de deformação (mecânica) relativa através da determinação da variação da resistência elétrica. Assim, dispositivos que efetuam esta correlação são chamados de extensômetro de resistência elétrica ou strain gauges. A utilização mais conhecida e mais extensa para os Strain Gauges é na construção de células de cargas, tipicamente utilizadas na fabricação de balanças eletrônicas dos mais diversos tipos. Isto é interessante uma vez que, a célula de carga construída a partir de strain gauges, gera um sinal elétrico proporcional ao esforço mecânico incidente sobre esta. Este sinal pode ser amostrado em um display ou tela, mostrando assim a massa (esforço mecânico) incidente.

